### PR TITLE
Dockerfile: ruby 2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-24-centos7:latest
+FROM centos/ruby-25-centos7:latest
 MAINTAINER Eguzki Astiz Lezaun <eastizle@redhat.com>
 
 USER root


### PR DESCRIPTION
Update ruby to 2.5

Supports http_proxy with user:pass basic authentication