### PR TITLE
Revert "solved #14 add entrypoint for dockerfile"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,3 @@ RUN TOOLBOX_VERSION=$(grep -P "^build_version '\d+\.\d+\.\d+'$" 3scale-toolbox.r
     --no-rdoc --no-ri"
 
 USER default
-
-ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
Docker image already has entrypoint inherited from base image. Inherited entry point actually is necessary to enable software collection library and allows ruby framework for 3scale toolbox.