### PR TITLE
Fix positional parameter expansion

### DIFF
--- a/config/templates/3scale-toolbox/3scale.erb
+++ b/config/templates/3scale-toolbox/3scale.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-<%= install_bin_dir %>/3scale $@
+<%= install_bin_dir %>/3scale "$@"


### PR DESCRIPTION
There is an issue with entrypoint script used in packages when positional parameters are quoted. Expansion is not correctly handled for special parameter `$@` when not quoted.

Clearly explained here:
https://wiki.bash-hackers.org/scripting/posparams#all_positional_parameters
https://www.thegeekstuff.com/2010/05/bash-shell-special-parameters/